### PR TITLE
Fix bug in image loader

### DIFF
--- a/script/drawSample.py
+++ b/script/drawSample.py
@@ -87,9 +87,10 @@ def main(args):
     fnames = None
 
   def getImgs(path):
-    imgPaths = du.GetImgPaths(imgPath)
+    imgPaths = du.GetImgPaths(path)
     if len(imgPaths) > 100:
-      du.imread(imgPaths[0]); imgs = du.ParforT(du.imread, imgPaths)
+      du.imread(imgPaths[0])
+      imgs = du.ParforT(du.imread, imgPaths)
     else:
       imgs = du.For(du.imread, imgPaths)
     return imgs


### PR DESCRIPTION
## Summary
- fix `getImgs()` helper to use `path` argument when loading image data

## Testing
- `python3 -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_6838265f96a88321a70761b7ec1b7c43